### PR TITLE
Port stacc to 1.20.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx2G
 
 # Mod Properties
-mod_version=1.6.2
+mod_version=1.6.2+1.20.1
 maven_group=net.devtech
 archives_base_name=stacc
 
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
-loader_version=0.14.21
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
+loader_version=0.14.25
 
 #Fabric api
-fabric_version=0.83.0+1.20
+fabric_version=0.91.0+1.20.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-org.gradle.jvmargs=-Xmx8G
+org.gradle.jvmargs=-Xmx1G
 
 # Mod Properties
 mod_version=1.6.2
 maven_group=net.devtech
 archives_base_name=stacc
 
-minecraft_version=1.19.4
-yarn_mappings=1.19.4+build.1
-loader_version=0.14.18
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.14.21
 
 #Fabric api
-fabric_version=0.76.0+1.19.4
+fabric_version=0.83.0+1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Mod Properties
-mod_version=1.6.2+1.20.1
+mod_version=1.7.0
 maven_group=net.devtech
 archives_base_name=stacc
 

--- a/src/main/java/net/devtech/stacc/mixin/ClearCommandBugFixin.java
+++ b/src/main/java/net/devtech/stacc/mixin/ClearCommandBugFixin.java
@@ -24,7 +24,7 @@ public class ClearCommandBugFixin {
 		StaccGlobals.COUNT.set(0L);
 	}
 
-	@ModifyArg (method = "execute",
+	@ModifyArg (method = {"method_51936", "method_51937", "method_51938", "method_51939"},
 			at = @At (value = "INVOKE", target = "Lnet/minecraft/text/Text;translatable(Ljava/lang/String;[Ljava/lang/Object;)Lnet/minecraft/text/MutableText;"),
 			index = 1)
 	private static Object[] exec(Object[] arr) {
@@ -35,8 +35,8 @@ public class ClearCommandBugFixin {
 	@Mixin (Inventories.class)
 	private static class InventoriesFixin {
 		@Inject (method = "remove(Lnet/minecraft/item/ItemStack;Ljava/util/function/Predicate;IZ)I",
-				at = @At (value = "RETURN"),
-				cancellable = true)
+				at = @At (value = "RETURN")
+        )
 		private static void total(ItemStack itemStack,
 				Predicate<ItemStack> predicate,
 				int i,

--- a/src/main/java/net/devtech/stacc/mixin/DesktopHandSplayedDuplicationFixin.java
+++ b/src/main/java/net/devtech/stacc/mixin/DesktopHandSplayedDuplicationFixin.java
@@ -14,7 +14,7 @@ import net.minecraft.util.math.MathHelper;
 @Mixin (ScreenHandler.class)
 public class DesktopHandSplayedDuplicationFixin {
 	@Redirect (method = "calculateStackSize", at = @At (value = "INVOKE", target = "Lnet/minecraft/util/math/MathHelper;floor(F)I"))
-	private static int floor(float input, Set<Slot> slots, int mode, ItemStack stack, int stackSize) {
+	private static int floor(float input, Set<Slot> slots, int mode, ItemStack stack) {
 		return MathHelper.floor((double) stack.getCount() / (double) slots.size());
 	}
 }

--- a/src/main/java/net/devtech/stacc/mixin/RenderItemCountFixin.java
+++ b/src/main/java/net/devtech/stacc/mixin/RenderItemCountFixin.java
@@ -1,7 +1,10 @@
 package net.devtech.stacc.mixin;
 
 import net.devtech.stacc.ItemCountRenderHandler;
+import net.minecraft.client.gui.DrawContext;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -9,7 +12,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.ItemStack;
 
@@ -17,29 +19,31 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 @Environment (EnvType.CLIENT)
-@Mixin (ItemRenderer.class)
+@Mixin (DrawContext.class)
 public class RenderItemCountFixin {
 
-	@Redirect (method = "renderGuiItemOverlay(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
+    @Shadow @Final private MatrixStack matrices;
+
+    @Redirect (method = "drawItemInSlot(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
 			at = @At (value = "INVOKE", target = "Ljava/lang/String;valueOf(I)Ljava/lang/String;"))
 	private String render(int i) {
 		return ItemCountRenderHandler.getInstance().toConsiseString(i);
 	}
 
-	@Redirect (method = "renderGuiItemOverlay(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
+	@Redirect (method = "drawItemInSlot(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
 			at = @At (value = "INVOKE", target = "Lnet/minecraft/client/font/TextRenderer;getWidth(Ljava/lang/String;)I"))
 	private int width(TextRenderer renderer, String text) {
 		return (int) (renderer.getWidth(text) * ItemCountRenderHandler.getInstance().scale(text));
 	}
 
-	@Inject (method = "renderGuiItemOverlay(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
+	@Inject (method = "drawItemInSlot(Lnet/minecraft/client/font/TextRenderer;Lnet/minecraft/item/ItemStack;IILjava/lang/String;)V",
 			at = @At (value = "INVOKE", target = "Lnet/minecraft/client/util/math/MatrixStack;translate(FFF)V", shift = At.Shift.AFTER),
 			locals = LocalCapture.CAPTURE_FAILHARD)
-	private void rescaleText(MatrixStack matrices, TextRenderer textRenderer, ItemStack stack, int x, int y, String countLabel, CallbackInfo ci, String string) {
+	private void rescaleText(TextRenderer textRenderer, ItemStack stack, int x, int y, String countOverride, CallbackInfo ci, String string) {
 		float f = ItemCountRenderHandler.getInstance().scale(string);
 		if (f != 1f) {
-			matrices.translate(x * (1 - f), y * (1 - f) + (1 - f) * 16, 0);
-			matrices.scale(f, f, f);
+			this.matrices.translate(x * (1 - f), y * (1 - f) + (1 - f) * 16, 0);
+			this.matrices.scale(f, f, f);
 		}
 	}
 }

--- a/src/main/java/net/devtech/stacc/mixin/SerializationFixin.java
+++ b/src/main/java/net/devtech/stacc/mixin/SerializationFixin.java
@@ -18,9 +18,6 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-
 /**
  * fixes ItemStack to serialize count as int instead of byte
  */


### PR DESCRIPTION
Ports stacc-api to 1.20.1. Potentially does not work in 1.20, due to small signature changes between the two versions. Tested on both Fabric Loader 0.14.25 and 0.15.3, and works on both. 

Versioning here uses the same version as a comment for Minecraft version, as this and #25 are mostly identical in content. Can change this on request to something like preferrable on request. 

Mention of `1.5.3-pre.1` in comitts is in regards to a pre-release JiJ we made for Numismatic Overhaul which is based off 8f0d4b1d